### PR TITLE
[DRAFT] fix(core): prevent IAM token refresh from blocking cluster operations

### DIFF
--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -88,7 +88,7 @@ struct PipelineMessage<S> {
 /// and `Sink`.
 #[derive(Clone)]
 pub(crate) struct Pipeline<SinkItem> {
-    sender: mpsc::Sender<PipelineMessage<SinkItem>>,
+    sender: mpsc::UnboundedSender<PipelineMessage<SinkItem>>,
     push_manager: Arc<ArcSwap<PushManager>>,
     is_stream_closed: Arc<AtomicBool>,
 }
@@ -475,8 +475,11 @@ where
         T::Error: Send,
         T::Error: ::std::fmt::Debug,
     {
-        const BUFFER_SIZE: usize = 50;
-        let (sender, mut receiver) = mpsc::channel(BUFFER_SIZE);
+        // Unbounded channel: prevents deadlock when the single Tokio worker thread
+        // is occupied by tasks awaiting TCP ACKs (cluster unreachable). A bounded
+        // channel causes send().await to suspend indefinitely, starving the
+        // PipelineSink task that must run to drain it — deadlocking the runtime.
+        let (sender, mut receiver) = mpsc::unbounded_channel();
         let push_manager: Arc<ArcSwap<PushManager>> =
             Arc::new(ArcSwap::new(Arc::new(PushManager::default())));
         let is_stream_closed = Arc::new(AtomicBool::new(false));
@@ -529,7 +532,6 @@ where
                 is_transaction: is_atomic,
                 is_fenced,
             })
-            .await
             .map_err(|err| {
                 // If an error occurs here, it means the request never reached the server, as guaranteed
                 // by the 'send' function. Since the server did not receive the data, it is safe to retry

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1344,9 +1344,15 @@ impl Client {
         move |new_token: String| {
             let client_arc = Arc::clone(&client_arc);
             tokio::spawn(async move {
-                let mut client = client_arc.write().await;
+                // Clone the client under a brief read lock, then drop the lock.
+                // update_connection_password does network I/O; holding write() for
+                // its entire duration blocks any concurrent client creation.
+                let mut client = {
+                    let guard = client_arc.read().await;
+                    guard.clone()
+                };
                 let result = client
-                    .update_connection_password(Some(new_token.clone()), true)
+                    .update_connection_password(Some(new_token.clone()), false)
                     .await;
 
                 if let Err(e) = result {


### PR DESCRIPTION
# DRAFT (AI ASSISTED FIX)
## Problem

When an IAM token refresh fires while the ElastiCache cluster is unreachable, `glideClient.del(keys).get()` blocks indefinitely and the executor queue grows unboundedly, eventually causing OOM.

### Root cause chain

1. `iam_callback` fires every `refreshIntervalSeconds` and calls `update_connection_password(token, immediate_auth=true)`
2. `immediate_auth=true` sends an `AUTH` command to **all cluster nodes** (`MultipleNodeRoutingInfo::AllNodes`)
3. With the cluster unreachable, this fan-out returns `AllConnectionsUnavailable`
4. `AllConnectionsUnavailable` triggers `ReconnectToInitialNodes` — putting `ClusterConnInner` into **Recover state**
5. While in Recover state, no new commands are processed
6. Combined with exponential retry backoff (up to 16 retries), this causes **15–21 second latency** before errors propagate
7. The Java executor queue grows unboundedly (producer adds ~6000 tasks/s, workers drain at ~3/s) → OOM

### Why `immediate_auth=true` is wrong

The intent was to re-authenticate existing connections immediately on token rotation. However:
- IAM tokens are valid for **15 minutes** and are refreshed every 5 minutes (production default) — there is a large safety margin
- ElastiCache validates IAM tokens **at connection time only** — once authenticated, a connection stays valid regardless of token expiry
- Every new connection created by the reconnect/slot-refresh logic already reads `cluster_params.password` via `get_connection_info()` and authenticates with the latest token automatically
- Sending AUTH to all nodes when the cluster may be unreachable is actively harmful

## Fix

### 1. `immediate_auth=false` in `iam_callback` (primary fix)

```rust
// glide-core/src/client/mod.rs
client.update_connection_password(Some(new_token.clone()), false).await;
```

Just update `cluster_params.password`. Every subsequent connection creation (reconnect, slot refresh, new node) reads this value and authenticates with the new token. No network I/O, no `AllConnectionsUnavailable`, no Recover state.

### 2. Drop `client_arc.write()` before network I/O (secondary)

```rust
// Before: held write lock for entire duration of update_connection_password
let mut client = client_arc.write().await;

// After: brief read lock to clone, then drop
let mut client = {
    let guard = client_arc.read().await;
    guard.clone()
};
```

`update_connection_password` does network I/O. Holding `write()` for its full duration unnecessarily blocks concurrent client creation.

### 3. Unbounded pipeline channel (defense-in-depth)

```rust
// glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
// Before:
const BUFFER_SIZE: usize = 50;
let (sender, mut receiver) = mpsc::channel(BUFFER_SIZE);
// ...
.send(...).await  // blocks if channel full

// After:
let (sender, mut receiver) = mpsc::unbounded_channel();
// ...
.send(...)  // never blocks
```

With `DEFAULT_RUNTIME_WORKER_THREADS=1`, a full bounded channel causes `send().await` to suspend indefinitely, starving `PipelineSink` and deadlocking the single Tokio worker thread. Making it unbounded eliminates this failure mode.

## Reproduction

Confirmed with live reproduction against ElastiCache Valkey 8.0.1 (3 shards × 3 replicas, IAM auth, `refreshIntervalSeconds=30`):

**Before fix** (after IAM refresh fires):
```
SYNC:         stuck=60, queue→9.5M, rate=0, errors frozen  ← DEADLOCK
SYNC+TIMEOUT: stuck=60, queue→∞                            ← also frozen
ASYNC:        inflight=50, rate=~5000/s                    ← unaffected
```

**After fix** (expected):
```
SYNC:         errors fast (~1ms, ConnectionNotFoundForRoute), queue=0
SYNC+TIMEOUT: errors fast (~1ms), queue=0
ASYNC:        errors fast (~0ms), queue=0
```
