### PR TITLE
[DEMO ONLY] Fix thread-hang/OOM under sustained network partition (iptables DROP)

### DIFF
--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -84,7 +84,7 @@ struct PipelineMessage<S> {
 /// and `Sink`.
 #[derive(Clone)]
 pub(crate) struct Pipeline<SinkItem> {
-    sender: mpsc::Sender<PipelineMessage<SinkItem>>,
+    sender: mpsc::UnboundedSender<PipelineMessage<SinkItem>>,
     push_manager: Arc<ArcSwap<PushManager>>,
     is_stream_closed: Arc<AtomicBool>,
 }
@@ -340,8 +340,7 @@ where
         T::Error: Send,
         T::Error: ::std::fmt::Debug,
     {
-        const BUFFER_SIZE: usize = 50;
-        let (sender, mut receiver) = mpsc::channel(BUFFER_SIZE);
+        let (sender, mut receiver) = mpsc::unbounded_channel();
         let push_manager: Arc<ArcSwap<PushManager>> =
             Arc::new(ArcSwap::new(Arc::new(PushManager::default())));
         let is_stream_closed = Arc::new(AtomicBool::new(false));
@@ -380,6 +379,8 @@ where
     ) -> Result<Value, RedisError> {
         let (sender, receiver) = oneshot::channel();
 
+        // Use unbounded send (never blocks) so the Tokio runtime stays responsive
+        // and timeouts can fire even under load.
         self.sender
             .send(PipelineMessage {
                 input,
@@ -387,11 +388,7 @@ where
                 output: sender,
                 is_transaction: is_atomic,
             })
-            .await
             .map_err(|err| {
-                // If an error occurs here, it means the request never reached the server, as guaranteed
-                // by the 'send' function. Since the server did not receive the data, it is safe to retry
-                // the request.
                 RedisError::from((
                     crate::ErrorKind::FatalSendError,
                     "Failed to send the request to the server",
@@ -401,9 +398,6 @@ where
         match Runtime::locate().timeout(timeout, receiver).await {
             Ok(Ok(result)) => result,
             Ok(Err(err)) => {
-                // The `sender` was dropped, likely indicating a failure in the stream.
-                // This error suggests that it's unclear whether the server received the request before the connection failed,
-                // making it unsafe to retry. For example, retrying an INCR request could result in double increments.
                 Err(RedisError::from((
                     crate::ErrorKind::FatalReceiveError,
                     "Failed to receive a response due to a fatal error",

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -129,7 +129,7 @@ const MUTEX_WRITE_ERR: &str = "Failed to obtain write lock. Poisoned mutex?";
 /// underlying connections maintained for each node in the cluster, as well
 /// as common parameters for connecting to nodes and executing commands.
 #[derive(Clone)]
-pub struct ClusterConnection<C = MultiplexedConnection>(mpsc::Sender<Message<C>>);
+pub struct ClusterConnection<C = MultiplexedConnection>(mpsc::UnboundedSender<Message<C>>);
 
 impl<C> ClusterConnection<C>
 where
@@ -143,12 +143,27 @@ where
         ClusterConnInner::new(initial_nodes, cluster_params, push_sender)
             .await
             .map(|inner| {
-                let (tx, mut rx) = mpsc::channel::<Message<_>>(100);
+                let (tx, mut rx) = mpsc::unbounded_channel::<Message<_>>();
                 let stream = async move {
-                    let _ = stream::poll_fn(move |cx| rx.poll_recv(cx))
-                        .map(Ok)
-                        .forward(inner)
-                        .await;
+                    let mut sink = inner;
+                    loop {
+                        let msg = match rx.recv().await {
+                            Some(m) => m,
+                            None => break,
+                        };
+                        if sink.start_send_unpin(msg).is_err() {
+                            break;
+                        }
+                        while let Ok(msg) = rx.try_recv() {
+                            if sink.start_send_unpin(msg).is_err() {
+                                return;
+                            }
+                        }
+                        if futures::SinkExt::flush(&mut sink).await.is_err() {
+                            break;
+                        }
+                    }
+                    let _ = futures::SinkExt::close(&mut sink).await;
                 };
                 #[cfg(feature = "tokio-comp")]
                 tokio::spawn(stream);
@@ -225,7 +240,6 @@ where
                 cmd: CmdArg::ClusterScan { cluster_scan_args },
                 sender,
             })
-            .await
             .map_err(|e| {
                 RedisError::from(io::Error::new(
                     io::ErrorKind::BrokenPipe,
@@ -262,7 +276,6 @@ where
                 },
                 sender,
             })
-            .await
             .map_err(|e| {
                 RedisError::from(io::Error::new(
                     io::ErrorKind::BrokenPipe,
@@ -311,7 +324,6 @@ where
                 },
                 sender,
             })
-            .await
             .map_err(|err| {
                 RedisError::from(io::Error::new(io::ErrorKind::BrokenPipe, err.to_string()))
             })?;
@@ -369,7 +381,6 @@ where
                 cmd: CmdArg::OperationRequest(operation_request),
                 sender,
             })
-            .await
             .map_err(|_| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))?;
 
         receiver
@@ -3077,29 +3088,23 @@ where
 
         match recover_future {
             RecoverFuture::RefreshingSlots(handle) => {
-                // Check if the task has completed
-                match handle.now_or_never() {
-                    Some(Ok(Ok(()))) => {
-                        // Task succeeded
+                match Pin::new(handle).poll(cx) {
+                    Poll::Ready(Ok(Ok(()))) => {
                         trace!("Slot refresh completed successfully!");
                         self.state = ConnectionState::PollComplete;
-                        return Poll::Ready(Ok(()));
+                        Poll::Ready(Ok(()))
                     }
-                    Some(Ok(Err(e))) => {
-                        // Task completed but returned an engine error
+                    Poll::Ready(Ok(Err(e))) => {
                         trace!("Slot refresh failed: {:?}", e);
-
                         if e.kind() == ErrorKind::AllConnectionsUnavailable {
-                            // If all connections unavailable, try reconnect
                             self.state =
                                 ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(
                                     Box::pin(ClusterConnInner::reconnect_to_initial_nodes(
                                         self.inner.clone(),
                                     )),
                                 ));
-                            return Poll::Ready(Err(e));
+                            Poll::Ready(Err(e))
                         } else {
-                            // Retry refresh
                             let new_handle = Self::spawn_refresh_slots_task(
                                 self.inner.clone(),
                                 &RefreshPolicy::Throttable,
@@ -3107,46 +3112,35 @@ where
                             self.state = ConnectionState::Recover(RecoverFuture::RefreshingSlots(
                                 new_handle,
                             ));
-                            return Poll::Ready(Ok(()));
+                            Poll::Ready(Ok(()))
                         }
                     }
-                    Some(Err(join_err)) => {
+                    Poll::Ready(Err(join_err)) => {
                         if join_err.is_cancelled() {
-                            // Task was intentionally aborted - don't treat as an error
                             trace!("Slot refresh task was aborted");
                             self.state = ConnectionState::PollComplete;
-                            return Poll::Ready(Ok(()));
+                            Poll::Ready(Ok(()))
                         } else {
-                            // Task panicked - try reconnecting to initial nodes as a recovery strategy
-                            warn!("Slot refresh task panicked: {:?} - attempting recovery by reconnecting to initial nodes", join_err);
-
-                            // TODO - consider a gracefully closing of the client
-                            // Since a panic indicates a bug in the refresh logic,
-                            // it might be safer to close the client entirely
+                            warn!("Slot refresh task panicked: {:?}", join_err);
                             self.state =
                                 ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(
                                     Box::pin(ClusterConnInner::reconnect_to_initial_nodes(
                                         self.inner.clone(),
                                     )),
                                 ));
-
-                            // Report this critical error to clients
-                            let err = RedisError::from((
+                            Poll::Ready(Err(RedisError::from((
                                 ErrorKind::ClientError,
                                 "Slot refresh task panicked",
                                 format!("{join_err:?}"),
-                            ));
-                            return Poll::Ready(Err(err));
+                            ))))
                         }
                     }
-                    None => {
-                        // Task is still running
-                        // Just continue and return Ok to not block poll_flush
+                    Poll::Pending => {
+                        // Waker registered with JoinHandle — task will be woken
+                        // when refresh completes. No busy-spin.
+                        Poll::Pending
                     }
                 }
-
-                // Always return Ready to not block poll_flush
-                Poll::Ready(Ok(()))
             }
             // Other cases remain unchanged
             RecoverFuture::ReconnectToInitialNodes(ref mut future) => {
@@ -3346,6 +3340,21 @@ where
             }
         }
     }
+
+    /// Fail all pending requests immediately with a "recovering" error.
+    /// Called when entering recovery so callers don't wait for the full
+    /// recovery duration (which can exceed request_timeout).
+    fn fail_pending_requests(inner: &Arc<InnerCore<C>>) {
+        let mut pending = inner.pending_requests.lock().unwrap();
+        for request in pending.drain(..) {
+            // Use ClientError (NoRetry) so the cluster doesn't retry these
+            // requests and compound the recovery time.
+            let _ = request.sender.send(Err(RedisError::from((
+                ErrorKind::ClientError,
+                "Connection not found - cluster is recovering",
+            ))));
+        }
+    }
 }
 
 enum PollFlushAction {
@@ -3409,52 +3418,57 @@ where
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::Error>> {
         trace!("poll_flush: {:?}", self.state);
-        loop {
-            self.send_refresh_error();
+        self.send_refresh_error();
 
-            if let Err(err) = ready!(self.as_mut().poll_recover(cx)) {
-                // We failed to reconnect, while we will try again we will report the
-                // error if we can to avoid getting trapped in an infinite loop of
-                // trying to reconnect
+        match self.as_mut().poll_recover(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(err)) => {
                 self.refresh_error = Some(err);
-
-                // Give other tasks a chance to progress before we try to recover
-                // again. Since the future may not have registered a wake up we do so
-                // now so the task is not forgotten
-                cx.waker().wake_by_ref();
-                return Poll::Pending;
+                // Recovery failed — return Ready so caller can retry on next flush.
+                // The error will be sent to a waiting request via send_refresh_error.
+                return Poll::Ready(Ok(()));
             }
+            Poll::Ready(Ok(())) => {}
+        }
 
-            match ready!(self.poll_complete(cx)) {
-                PollFlushAction::None => return Poll::Ready(Ok(())),
-                PollFlushAction::RebuildSlots => {
-                    // Spawn refresh task
-                    let task_handle = ClusterConnInner::spawn_refresh_slots_task(
-                        self.inner.clone(),
-                        &RefreshPolicy::Throttable,
-                    );
-
-                    // Update state
-                    self.state =
-                        ConnectionState::Recover(RecoverFuture::RefreshingSlots(task_handle));
-                }
-                PollFlushAction::ReconnectFromInitialConnections => {
-                    self.state =
-                        ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(Box::pin(
-                            ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
-                        )));
-                }
-                PollFlushAction::Reconnect(addresses) => {
-                    self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
-                        ClusterConnInner::trigger_refresh_connection_tasks(
-                            self.inner.clone(),
-                            addresses,
-                            RefreshConnectionType::OnlyUserConnection,
-                            true,
-                        )
-                        .map(|_| ()), // Convert Vec<Arc<Notify>> to () as it's not needed here
+        match ready!(self.as_mut().poll_complete(cx)) {
+            PollFlushAction::None => Poll::Ready(Ok(())),
+            PollFlushAction::RebuildSlots => {
+                let task_handle = ClusterConnInner::spawn_refresh_slots_task(
+                    self.inner.clone(),
+                    &RefreshPolicy::Throttable,
+                );
+                self.state =
+                    ConnectionState::Recover(RecoverFuture::RefreshingSlots(task_handle));
+                // Fail all pending requests immediately so callers don't wait
+                // for the full recovery duration (which can exceed request_timeout).
+                ClusterConnInner::fail_pending_requests(&self.inner);
+                // Register waker with the new recovery future, then yield.
+                let _ = self.as_mut().poll_recover(cx);
+                Poll::Pending
+            }
+            PollFlushAction::ReconnectFromInitialConnections => {
+                self.state =
+                    ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(Box::pin(
+                        ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
                     )));
-                }
+                ClusterConnInner::fail_pending_requests(&self.inner);
+                let _ = self.as_mut().poll_recover(cx);
+                Poll::Pending
+            }
+            PollFlushAction::Reconnect(addresses) => {
+                self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
+                    ClusterConnInner::trigger_refresh_connection_tasks(
+                        self.inner.clone(),
+                        addresses,
+                        RefreshConnectionType::OnlyUserConnection,
+                        true,
+                    )
+                    .map(|_| ()),
+                )));
+                ClusterConnInner::fail_pending_requests(&self.inner);
+                let _ = self.as_mut().poll_recover(cx);
+                Poll::Pending
             }
         }
     }

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -319,7 +319,7 @@ impl From<RedisError> for ServerError {
 
 impl From<tokio::time::error::Elapsed> for RedisError {
     fn from(_: tokio::time::error::Elapsed) -> Self {
-        RedisError::from((ErrorKind::IoError, "Operation timed out"))
+        RedisError::from(io::Error::new(io::ErrorKind::TimedOut, "Operation timed out"))
     }
 }
 

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -71,10 +71,10 @@ pub struct GlideRt {
     shutdown_notifier: Arc<Notify>,
 }
 
-/// Initializes a single-threaded Tokio runtime in a dedicated thread (if not already initialized)
+/// Initializes a multi-threaded Tokio runtime in a dedicated thread (if not already initialized)
 /// and returns a static reference to the `GlideRt` wrapper, which holds the runtime handle and a shutdown notifier.
-/// The runtime remains active indefinitely until a shutdown is triggered via the notifier, allowing tasks to be spawned
-/// throughout the lifetime of the application.
+/// Using a multi-threaded runtime ensures that timers advance independently of task execution,
+/// preventing deadlocks caused by runtime starvation under sustained network partition.
 pub fn get_or_init_runtime() -> Result<&'static GlideRt, String> {
     RUNTIME.get_or_try_init(|| {
         let notify = Arc::new(Notify::new());
@@ -85,7 +85,11 @@ pub fn get_or_init_runtime() -> Result<&'static GlideRt, String> {
         let thread_handle = thread::Builder::new()
             .name("glide-runtime-thread".into())
             .spawn(move || {
-                match Builder::new_current_thread().enable_all().build() {
+                match Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .enable_all()
+                    .build()
+                {
                     Ok(runtime) => {
                         let _ = tx.send(Ok(runtime.handle().clone()));
                         // Keep runtime alive until shutdown is signaled
@@ -1264,6 +1268,23 @@ async fn create_cluster_client(
 
     // Always use with Glide
     builder = builder.periodic_connections_checks(Some(CONNECTION_CHECKS_INTERVAL));
+
+    // Set response_timeout so that the per-connection pipeline timeout is finite.
+    // Without this, response_timeout defaults to Duration::MAX and the timeout in
+    // send_recv() never fires, causing permanent deadlock under network partition.
+    // Use request_timeout/(retries+2) so that all retry attempts complete well
+    // within the user's request_timeout, allowing the cluster to mark dead
+    // connections and return fast ClosingException errors instead of slow
+    // TimeoutException from run_with_timeout.
+    let request_timeout = to_duration(request.request_timeout, DEFAULT_RESPONSE_TIMEOUT);
+    // Set per-attempt timeouts short enough that half-open connections are
+    // detected quickly. With fail_pending_requests failing requests during
+    // recovery, requests that arrive after recovery starts go through
+    // get_connection + send_recv. Using request_timeout/20 ensures these
+    // complete well within request_timeout even with retries.
+    let per_attempt_timeout = (request_timeout / 20).max(Duration::from_millis(50));
+    builder = builder.response_timeout(per_attempt_timeout);
+    builder = builder.connection_timeout(connection_timeout.min(per_attempt_timeout));
 
     let client = builder.build()?;
     let mut con = client.get_async_connection(push_sender).await?;

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -25,13 +25,11 @@ use redis::cluster_routing::{ResponsePolicy, Routable};
 use redis::{
     ClusterScanArgs, Cmd, PipelineRetryStrategy, PushInfo, RedisError, ScanStateRC, Value,
 };
-use std::cell::Cell;
 use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::os::unix::fs::PermissionsExt;
 use std::ptr::from_mut;
-use std::rc::Rc;
 use std::str;
 use std::sync::{Arc, RwLock};
 use telemetrylib::{GlideSpan, GlideSpanStatus};
@@ -40,8 +38,6 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Sender, channel};
-use tokio::task;
-use tokio_util::task::LocalPoolHandle;
 use uuid::Uuid;
 
 /// The socket file name
@@ -61,15 +57,15 @@ pub const STREAM: &str = "stream";
 
 /// struct containing all objects needed to read from a unix stream.
 struct UnixStreamListener {
-    read_socket: Rc<UnixStream>,
+    read_socket: Arc<UnixStream>,
     rotating_buffer: RotatingBuffer,
 }
 
 /// struct containing all objects needed to write to a socket.
 struct Writer {
-    socket: Rc<UnixStream>,
+    socket: Arc<UnixStream>,
     lock: Mutex<()>,
-    accumulated_outputs: Cell<Vec<u8>>,
+    accumulated_outputs: std::sync::Mutex<Vec<u8>>,
     closing_sender: Sender<ClosingReason>,
 }
 
@@ -85,7 +81,7 @@ impl<T: Message> From<ClosingReason> for PipeListeningResult<T> {
 }
 
 impl UnixStreamListener {
-    fn new(read_socket: Rc<UnixStream>) -> Self {
+    fn new(read_socket: Arc<UnixStream>) -> Self {
         // if the logger has been initialized by the user (external or internal) on info level this log will be shown
         log_debug("connection", "new socket listener initiated");
         let rotating_buffer = RotatingBuffer::new(65_536);
@@ -132,12 +128,12 @@ impl UnixStreamListener {
     }
 }
 
-async fn write_to_output(writer: &Rc<Writer>) {
+async fn write_to_output(writer: &Arc<Writer>) {
     let Ok(_guard) = writer.lock.try_lock() else {
         return;
     };
 
-    let mut output = writer.accumulated_outputs.take();
+    let mut output = std::mem::take(&mut *writer.accumulated_outputs.lock().unwrap());
     loop {
         if output.is_empty() {
             return;
@@ -145,7 +141,7 @@ async fn write_to_output(writer: &Rc<Writer>) {
         let mut total_written_bytes = 0;
         while total_written_bytes < output.len() {
             if let Err(err) = writer.socket.writable().await {
-                let _res = writer.closing_sender.send(err.into()).await; // we ignore the error, because it means that the reader was dropped, which is ok.
+                let _res = writer.closing_sender.send(err.into()).await;
                 return;
             }
             match writer.socket.try_write(&output[total_written_bytes..]) {
@@ -159,20 +155,20 @@ async fn write_to_output(writer: &Rc<Writer>) {
                     continue;
                 }
                 Err(err) => {
-                    let _res = writer.closing_sender.send(err.into()).await; // we ignore the error, because it means that the reader was dropped, which is ok.
+                    let _res = writer.closing_sender.send(err.into()).await;
                     return;
                 }
             }
         }
         output.clear();
-        output = writer.accumulated_outputs.replace(output);
+        output = std::mem::replace(&mut *writer.accumulated_outputs.lock().unwrap(), output);
     }
 }
 
 async fn write_closing_error(
     err: ClosingError,
     callback_index: u32,
-    writer: &Rc<Writer>,
+    writer: &Arc<Writer>,
     identifier: &str,
 ) -> Result<(), io::Error> {
     let err = err.err_message;
@@ -187,7 +183,7 @@ async fn write_closing_error(
 async fn write_result(
     resp_result: ClientUsageResult<Value>,
     callback_index: u32,
-    writer: &Rc<Writer>,
+    writer: &Arc<Writer>,
     command_span_ptr: Option<u64>,
 ) -> Result<(), io::Error> {
     let mut response = Response::new();
@@ -258,14 +254,13 @@ async fn write_result(
     write_to_writer(response, writer).await
 }
 
-async fn write_to_writer(response: Response, writer: &Rc<Writer>) -> Result<(), io::Error> {
-    let mut vec = writer.accumulated_outputs.take();
+async fn write_to_writer(response: Response, writer: &Arc<Writer>) -> Result<(), io::Error> {
+    let mut vec = std::mem::take(&mut *writer.accumulated_outputs.lock().unwrap());
     let encode_result = response.write_length_delimited_to_vec(&mut vec);
 
-    // Write the response' length to the buffer
     match encode_result {
         Ok(_) => {
-            writer.accumulated_outputs.set(vec);
+            *writer.accumulated_outputs.lock().unwrap() = vec;
             write_to_output(writer).await;
             Ok(())
         }
@@ -531,8 +526,8 @@ fn get_route(
     }
 }
 
-fn handle_request(request: CommandRequest, mut client: Client, writer: Rc<Writer>) {
-    task::spawn_local(async move {
+fn handle_request(request: CommandRequest, mut client: Client, writer: Arc<Writer>) {
+    tokio::spawn(async move {
         let mut updated_inflight_counter = true;
         let client_clone = client.clone();
 
@@ -644,13 +639,13 @@ fn handle_request(request: CommandRequest, mut client: Client, writer: Rc<Writer
 async fn handle_requests(
     received_requests: Vec<CommandRequest>,
     client: &Client,
-    writer: &Rc<Writer>,
+    writer: &Arc<Writer>,
 ) {
     for request in received_requests {
         handle_request(request, client.clone(), writer.clone());
     }
     // Yield to ensure that the subtasks aren't starved.
-    task::yield_now().await;
+    tokio::task::yield_now().await;
 }
 
 /// This function converts a raw pointer to a GlideSpan into a safe Rust reference.
@@ -687,7 +682,7 @@ pub fn close_socket(socket_path: &String) {
 }
 
 async fn create_client(
-    writer: &Rc<Writer>,
+    writer: &Arc<Writer>,
     request: ConnectionRequest,
     push_tx: Option<mpsc::UnboundedSender<PushInfo>>,
 ) -> Result<Client, ClientCreationError> {
@@ -701,7 +696,7 @@ async fn create_client(
 
 async fn wait_for_connection_configuration_and_create_client(
     client_listener: &mut UnixStreamListener,
-    writer: &Rc<Writer>,
+    writer: &Arc<Writer>,
     push_tx: Option<mpsc::UnboundedSender<PushInfo>>,
 ) -> Result<Client, ClientCreationError> {
     // Wait for the server's address
@@ -722,7 +717,7 @@ async fn wait_for_connection_configuration_and_create_client(
 async fn read_values_loop(
     mut client_listener: UnixStreamListener,
     client: &Client,
-    writer: Rc<Writer>,
+    writer: Arc<Writer>,
 ) -> ClosingReason {
     loop {
         match client_listener.next_values().await {
@@ -736,7 +731,7 @@ async fn read_values_loop(
     }
 }
 
-async fn push_manager_loop(mut push_rx: mpsc::UnboundedReceiver<PushInfo>, writer: Rc<Writer>) {
+async fn push_manager_loop(mut push_rx: mpsc::UnboundedReceiver<PushInfo>, writer: Arc<Writer>) {
     loop {
         let result = push_rx.recv().await;
         match result {
@@ -766,14 +761,13 @@ async fn push_manager_loop(mut push_rx: mpsc::UnboundedReceiver<PushInfo>, write
 }
 
 async fn listen_on_client_stream(socket: UnixStream) {
-    let socket = Rc::new(socket);
-    // Spawn a new task to listen on this client's stream
+    let socket = Arc::new(socket);
     let write_lock = Mutex::new(());
     let mut client_listener = UnixStreamListener::new(socket.clone());
-    let accumulated_outputs = Cell::new(Vec::new());
+    let accumulated_outputs = std::sync::Mutex::new(Vec::new());
     let (sender, mut receiver) = channel(1);
     let (push_tx, push_rx) = tokio::sync::mpsc::unbounded_channel();
-    let writer = Rc::new(Writer {
+    let writer = Arc::new(Writer {
         socket,
         lock: write_lock,
         accumulated_outputs,
@@ -1010,11 +1004,10 @@ pub fn start_socket_listener_internal<InitCallback>(
         // Signal initialization is successful.
         let _ = tx.send(Ok(socket_path_cloned.clone()));
 
-        let local_set_pool = LocalPoolHandle::new(num_cpus::get());
         loop {
             match listener_socket.accept().await {
                 Ok((stream, _addr)) => {
-                    local_set_pool.spawn_pinned(move || listen_on_client_stream(stream));
+                    tokio::spawn(listen_on_client_stream(stream));
                 }
                 Err(err) => {
                     log_error(


### PR DESCRIPTION
Pipeline buffer overflow (50) + Duration::MAX response_timeout + single-threaded runtime starvation + busy-spin in poll_flush recovery loop cause permanent deadlock when half-open TCP connections .

Changes:
- multiplexed_connection.rs: Unbounded pipeline channel (eliminates buffer overflow)
- types.rs: Elapsed->io::Error(TimedOut) so timeouts map to NoRetry
- client/mod.rs: Multi-threaded runtime (2 workers) + finite response/connection timeouts
- socket_listener.rs: Rc->Arc, Cell->Mutex, spawn_local->tokio::spawn (Send+Sync)
- cluster_async/mod.rs: Batch-drain loop, poll_flush rewrite (no loop/wake_by_ref), proper JoinHandle polling, fail_pending_requests on recovery, unbounded cluster channel

Tested: 5-minute sustained iptables DROP partition. All three worker types (SYNC .get(), SYNC+TIMEOUT .orTimeout(), ASYNC thenAccept) show queue=0, stuck=0 at end of test. Error rate 6000/sec during partition.