### PR TITLE
fix: prevent Tokio runtime starvation during network partition (try_send)

### DIFF
--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -1,4 +1,5 @@
 use super::{ConnectionLike, Runtime};
+use tracing::warn;
 use crate::aio::setup_connection;
 use crate::aio::DisconnectNotifier;
 use crate::client::GlideConnectionOptions;
@@ -380,24 +381,41 @@ where
     ) -> Result<Value, RedisError> {
         let (sender, receiver) = oneshot::channel();
 
-        self.sender
-            .send(PipelineMessage {
+        // Use send() with a 100ms timeout instead of send().await (unbounded wait).
+        // The pipeline channel is bounded (50 slots). Under normal operation, a slot
+        // frees in microseconds as the pipeline driver drains the channel. If the
+        // channel is still full after 100ms, the connection is likely dead (e.g.,
+        // half-open TCP from a network partition). Without this timeout, send().await
+        // blocks the calling task indefinitely, which starves the single-threaded
+        // Tokio runtime and prevents all timers (request_timeout, response_timeout)
+        // from firing — causing CompletableFuture.get() to hang forever in Java.
+        match tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            self.sender.send(PipelineMessage {
                 input,
                 pipeline_response_count,
                 output: sender,
                 is_transaction: is_atomic,
-            })
-            .await
-            .map_err(|err| {
-                // If an error occurs here, it means the request never reached the server, as guaranteed
-                // by the 'send' function. Since the server did not receive the data, it is safe to retry
-                // the request.
-                RedisError::from((
+            }),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                return Err(RedisError::from((
                     crate::ErrorKind::FatalSendError,
                     "Failed to send the request to the server",
                     err.to_string(),
-                ))
-            })?;
+                )));
+            }
+            Err(_) => {
+                crate::cluster_async::PIPELINE_SEND_TIMEOUT.fetch_add(1, crate::cluster_async::DiagOrdering::Relaxed);
+                return Err(RedisError::from((
+                    crate::ErrorKind::FatalSendError,
+                    "Pipeline channel full for 100ms — connection likely dead",
+                )));
+            }
+        }
         match Runtime::locate().timeout(timeout, receiver).await {
             Ok(Ok(result)) => result,
             Ok(Err(err)) => {
@@ -410,7 +428,10 @@ where
                     err.to_string(),
                 )))
             }
-            Err(elapsed) => Err(elapsed.into()),
+            Err(elapsed) => {
+                warn!("send_recv: response_timeout fired after {}ms", timeout.as_millis());
+                Err(elapsed.into())
+            }
         }
     }
 

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -407,7 +407,9 @@ where
                     err.to_string(),
                 )));
             }
-            Err(_) => {
+            Err(_elapsed) => {
+                // tokio::time::timeout expired — pipeline channel was full for 100ms,
+                // meaning the pipeline driver is stuck (likely dead TCP connection).
                 return Err(RedisError::from((
                     crate::ErrorKind::FatalSendError,
                     "Pipeline channel full for 100ms — connection likely dead",

--- a/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs
@@ -1,5 +1,4 @@
 use super::{ConnectionLike, Runtime};
-use tracing::warn;
 use crate::aio::setup_connection;
 use crate::aio::DisconnectNotifier;
 use crate::client::GlideConnectionOptions;
@@ -409,7 +408,6 @@ where
                 )));
             }
             Err(_) => {
-                crate::cluster_async::PIPELINE_SEND_TIMEOUT.fetch_add(1, crate::cluster_async::DiagOrdering::Relaxed);
                 return Err(RedisError::from((
                     crate::ErrorKind::FatalSendError,
                     "Pipeline channel full for 100ms — connection likely dead",
@@ -428,10 +426,7 @@ where
                     err.to_string(),
                 )))
             }
-            Err(elapsed) => {
-                warn!("send_recv: response_timeout fired after {}ms", timeout.as_millis());
-                Err(elapsed.into())
-            }
+            Err(elapsed) => Err(elapsed.into()),
         }
     }
 

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3111,14 +3111,17 @@ where
                 match Pin::new(handle).poll(cx) {
                     Poll::Pending => return Poll::Pending,
                     Poll::Ready(Ok(Ok(()))) => {
+                        // Task succeeded
                         trace!("Slot refresh completed successfully!");
                         self.state = ConnectionState::PollComplete;
                         Poll::Ready(Ok(()))
                     }
                     Poll::Ready(Ok(Err(e))) => {
+                        // Task completed but returned an engine error
                         trace!("Slot refresh failed: {:?}", e);
 
                         if e.kind() == ErrorKind::AllConnectionsUnavailable {
+                            // If all connections unavailable, try reconnect
                             self.state =
                                 ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(
                                     Box::pin(ClusterConnInner::reconnect_to_initial_nodes(
@@ -3127,6 +3130,7 @@ where
                                 ));
                             Poll::Ready(Err(e))
                         } else {
+                            // Retry refresh
                             let new_handle = Self::spawn_refresh_slots_task(
                                 self.inner.clone(),
                                 &RefreshPolicy::Throttable,
@@ -3139,17 +3143,24 @@ where
                     }
                     Poll::Ready(Err(join_err)) => {
                         if join_err.is_cancelled() {
+                            // Task was intentionally aborted - don't treat as an error
                             trace!("Slot refresh task was aborted");
                             self.state = ConnectionState::PollComplete;
                             Poll::Ready(Ok(()))
                         } else {
+                            // Task panicked - try reconnecting to initial nodes as a recovery strategy
                             warn!("Slot refresh task panicked: {:?} - attempting recovery by reconnecting to initial nodes", join_err);
+
+                            // TODO - consider a gracefully closing of the client
+                            // Since a panic indicates a bug in the refresh logic,
+                            // it might be safer to close the client entirely
                             self.state =
                                 ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(
                                     Box::pin(ClusterConnInner::reconnect_to_initial_nodes(
                                         self.inner.clone(),
                                     )),
                                 ));
+                            // Report this critical error to clients
                             let err = RedisError::from((
                                 ErrorKind::ClientError,
                                 "Slot refresh task panicked",
@@ -3483,10 +3494,12 @@ where
             }
             Poll::Ready(PollFlushAction::RebuildSlots) => {
                 POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
+                // Spawn refresh task
                 let task_handle = ClusterConnInner::spawn_refresh_slots_task(
                     self.inner.clone(),
                     &RefreshPolicy::Throttable,
                 );
+                // Update state
                 self.state =
                     ConnectionState::Recover(RecoverFuture::RefreshingSlots(task_handle));
                 cx.waker().wake_by_ref();
@@ -3510,7 +3523,7 @@ where
                         RefreshConnectionType::OnlyUserConnection,
                         true,
                     )
-                    .map(|_| ()),
+                    .map(|_| ()), // Convert Vec<Arc<Notify>> to () as it's not needed here
                 )));
                 cx.waker().wake_by_ref();
                 Poll::Pending

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -110,43 +110,6 @@ use dispose::{Disposable, Dispose};
 use futures::{future::BoxFuture, prelude::*, ready};
 use pin_project_lite::pin_project;
 use std::sync::RwLock as StdRwLock;
-use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-
-// Diagnostic counters for detecting poll_flush busy-spin during partition.
-pub(crate) static POLL_FLUSH_CALLS: AtomicU64 = AtomicU64::new(0);
-static POLL_RECOVER_READY: AtomicU64 = AtomicU64::new(0);
-static POLL_RECOVER_PENDING: AtomicU64 = AtomicU64::new(0);
-static POLL_COMPLETE_READY: AtomicU64 = AtomicU64::new(0);
-static POLL_COMPLETE_PENDING: AtomicU64 = AtomicU64::new(0);
-pub(crate) static PIPELINE_SEND_TIMEOUT: AtomicU64 = AtomicU64::new(0);
-pub(crate) static LAST_DIAG_LOG: AtomicU64 = AtomicU64::new(0);
-pub(crate) use std::sync::atomic::Ordering as DiagOrdering;
-
-fn log_diag_counters() {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let last = LAST_DIAG_LOG.load(AtomicOrdering::Relaxed);
-    if now.saturating_sub(last) < 5 {
-        return;
-    }
-    if LAST_DIAG_LOG.compare_exchange(last, now, AtomicOrdering::Relaxed, AtomicOrdering::Relaxed).is_err() {
-        return;
-    }
-    let flush = POLL_FLUSH_CALLS.swap(0, AtomicOrdering::Relaxed);
-    let rec_ready = POLL_RECOVER_READY.swap(0, AtomicOrdering::Relaxed);
-    let rec_pend = POLL_RECOVER_PENDING.swap(0, AtomicOrdering::Relaxed);
-    let comp_ready = POLL_COMPLETE_READY.swap(0, AtomicOrdering::Relaxed);
-    let comp_pend = POLL_COMPLETE_PENDING.swap(0, AtomicOrdering::Relaxed);
-    let send_to = PIPELINE_SEND_TIMEOUT.swap(0, AtomicOrdering::Relaxed);
-    if flush > 0 {
-        warn!(
-            "DIAG poll_flush={} recover(ready={},pending={}) complete(ready={},pending={}) pipe_send_timeout={}",
-            flush, rec_ready, rec_pend, comp_ready, comp_pend, send_to
-        );
-    }
-}
 use tokio::sync::{
     mpsc,
     oneshot::{self, Receiver},
@@ -3453,8 +3416,6 @@ where
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::Error>> {
         trace!("poll_flush: {:?}", self.state);
-        POLL_FLUSH_CALLS.fetch_add(1, AtomicOrdering::Relaxed);
-        log_diag_counters();
         // No loop{} here — when recovery is needed, we enter recovery state and
         // return Pending. The batch-drain loop will re-call flush() which re-polls
         // us. This prevents busy-spinning the single-threaded Tokio runtime during
@@ -3463,7 +3424,6 @@ where
 
         match self.as_mut().poll_recover(cx) {
             Poll::Pending => {
-                POLL_RECOVER_PENDING.fetch_add(1, AtomicOrdering::Relaxed);
                 // Fail any requests that Forward put into pending_requests
                 // via start_send while we're in recovery. Without this,
                 // those requests wait for recovery to complete (~seconds),
@@ -3472,28 +3432,22 @@ where
                 return Poll::Pending;
             }
             Poll::Ready(Err(err)) => {
-                POLL_RECOVER_READY.fetch_add(1, AtomicOrdering::Relaxed);
                 self.refresh_error = Some(err);
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
-            Poll::Ready(Ok(())) => {
-                POLL_RECOVER_READY.fetch_add(1, AtomicOrdering::Relaxed);
-            }
+            Poll::Ready(Ok(())) => {}
         }
 
         let poll_complete_result = self.as_mut().poll_complete(cx);
         match poll_complete_result {
             Poll::Pending => {
-                POLL_COMPLETE_PENDING.fetch_add(1, AtomicOrdering::Relaxed);
                 return Poll::Pending;
             }
             Poll::Ready(PollFlushAction::None) => {
-                POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
                 Poll::Ready(Ok(()))
             }
             Poll::Ready(PollFlushAction::RebuildSlots) => {
-                POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
                 // Spawn refresh task
                 let task_handle = ClusterConnInner::spawn_refresh_slots_task(
                     self.inner.clone(),
@@ -3506,7 +3460,6 @@ where
                 Poll::Pending
             }
             Poll::Ready(PollFlushAction::ReconnectFromInitialConnections) => {
-                POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
                 self.state =
                     ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(Box::pin(
                         ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
@@ -3515,7 +3468,6 @@ where
                 Poll::Pending
             }
             Poll::Ready(PollFlushAction::Reconnect(addresses)) => {
-                POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
                 self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
                     ClusterConnInner::trigger_refresh_connection_tasks(
                         self.inner.clone(),

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -3483,7 +3483,6 @@ where
             }
             Poll::Ready(PollFlushAction::RebuildSlots) => {
                 POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
-                ClusterConnInner::fail_pending_requests(&self.inner);
                 let task_handle = ClusterConnInner::spawn_refresh_slots_task(
                     self.inner.clone(),
                     &RefreshPolicy::Throttable,
@@ -3495,7 +3494,6 @@ where
             }
             Poll::Ready(PollFlushAction::ReconnectFromInitialConnections) => {
                 POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
-                ClusterConnInner::fail_pending_requests(&self.inner);
                 self.state =
                     ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(Box::pin(
                         ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
@@ -3505,7 +3503,6 @@ where
             }
             Poll::Ready(PollFlushAction::Reconnect(addresses)) => {
                 POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
-                ClusterConnInner::fail_pending_requests(&self.inner);
                 self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
                     ClusterConnInner::trigger_refresh_connection_tasks(
                         self.inner.clone(),

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -110,6 +110,43 @@ use dispose::{Disposable, Dispose};
 use futures::{future::BoxFuture, prelude::*, ready};
 use pin_project_lite::pin_project;
 use std::sync::RwLock as StdRwLock;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+// Diagnostic counters for detecting poll_flush busy-spin during partition.
+pub(crate) static POLL_FLUSH_CALLS: AtomicU64 = AtomicU64::new(0);
+static POLL_RECOVER_READY: AtomicU64 = AtomicU64::new(0);
+static POLL_RECOVER_PENDING: AtomicU64 = AtomicU64::new(0);
+static POLL_COMPLETE_READY: AtomicU64 = AtomicU64::new(0);
+static POLL_COMPLETE_PENDING: AtomicU64 = AtomicU64::new(0);
+pub(crate) static PIPELINE_SEND_TIMEOUT: AtomicU64 = AtomicU64::new(0);
+pub(crate) static LAST_DIAG_LOG: AtomicU64 = AtomicU64::new(0);
+pub(crate) use std::sync::atomic::Ordering as DiagOrdering;
+
+fn log_diag_counters() {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let last = LAST_DIAG_LOG.load(AtomicOrdering::Relaxed);
+    if now.saturating_sub(last) < 5 {
+        return;
+    }
+    if LAST_DIAG_LOG.compare_exchange(last, now, AtomicOrdering::Relaxed, AtomicOrdering::Relaxed).is_err() {
+        return;
+    }
+    let flush = POLL_FLUSH_CALLS.swap(0, AtomicOrdering::Relaxed);
+    let rec_ready = POLL_RECOVER_READY.swap(0, AtomicOrdering::Relaxed);
+    let rec_pend = POLL_RECOVER_PENDING.swap(0, AtomicOrdering::Relaxed);
+    let comp_ready = POLL_COMPLETE_READY.swap(0, AtomicOrdering::Relaxed);
+    let comp_pend = POLL_COMPLETE_PENDING.swap(0, AtomicOrdering::Relaxed);
+    let send_to = PIPELINE_SEND_TIMEOUT.swap(0, AtomicOrdering::Relaxed);
+    if flush > 0 {
+        warn!(
+            "DIAG poll_flush={} recover(ready={},pending={}) complete(ready={},pending={}) pipe_send_timeout={}",
+            flush, rec_ready, rec_pend, comp_ready, comp_pend, send_to
+        );
+    }
+}
 use tokio::sync::{
     mpsc,
     oneshot::{self, Receiver},
@@ -154,6 +191,19 @@ where
                 tokio::spawn(stream);
                 ClusterConnection(tx)
             })
+    }
+
+    /// Send a message to the cluster task. Uses regular send().await
+    /// to preserve backpressure — the cluster task needs quiet windows
+    /// during recovery to refresh connections. Fast error delivery is
+    /// handled by fail_pending_requests inside poll_flush instead.
+    async fn send_msg(&self, msg: Message<C>) -> RedisResult<()> {
+        self.0.send(msg).await.map_err(|e| {
+            RedisError::from(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                format!("Cluster channel closed: {e:?}"),
+            ))
+        })
     }
 
     /// Special handling for `SCAN` command, using `cluster_scan_with_pattern`.
@@ -220,18 +270,10 @@ where
         cluster_scan_args: ClusterScanArgs,
     ) -> RedisResult<(ScanStateRC, Vec<Value>)> {
         let (sender, receiver) = oneshot::channel();
-        self.0
-            .send(Message {
+        self.send_msg(Message {
                 cmd: CmdArg::ClusterScan { cluster_scan_args },
                 sender,
-            })
-            .await
-            .map_err(|e| {
-                RedisError::from(io::Error::new(
-                    io::ErrorKind::BrokenPipe,
-                    format!("Cluster: Error occurred while trying to send SCAN command to internal send task. {e:?}"),
-                ))
-            })?;
+            }).await?;
         receiver
             .await
             .unwrap_or_else(|e| {
@@ -254,21 +296,13 @@ where
     ) -> RedisResult<Value> {
         trace!("route_command");
         let (sender, receiver) = oneshot::channel();
-        self.0
-            .send(Message {
+        self.send_msg(Message {
                 cmd: CmdArg::Cmd {
                     cmd: Arc::new(cmd.clone()),
                     routing: routing.into(),
                 },
                 sender,
-            })
-            .await
-            .map_err(|e| {
-                RedisError::from(io::Error::new(
-                    io::ErrorKind::BrokenPipe,
-                    format!("Cluster: Error occurred while trying to send command to internal sender. {e:?}"),
-                ))
-            })?;
+            }).await?;
         receiver
             .await
             .unwrap_or_else(|e| {
@@ -299,8 +333,7 @@ where
         pipeline_retry_strategy: Option<PipelineRetryStrategy>,
     ) -> RedisResult<Vec<Value>> {
         let (sender, receiver) = oneshot::channel();
-        self.0
-            .send(Message {
+        self.send_msg(Message {
                 cmd: CmdArg::Pipeline {
                     pipeline: Arc::new(pipeline.clone()),
                     offset,
@@ -310,11 +343,7 @@ where
                     pipeline_retry_strategy: pipeline_retry_strategy.unwrap_or_default(),
                 },
                 sender,
-            })
-            .await
-            .map_err(|err| {
-                RedisError::from(io::Error::new(io::ErrorKind::BrokenPipe, err.to_string()))
-            })?;
+            }).await?;
 
         receiver
             .await
@@ -364,13 +393,10 @@ where
         operation_request: Operation,
     ) -> RedisResult<Value> {
         let (sender, receiver) = oneshot::channel();
-        self.0
-            .send(Message {
+        self.send_msg(Message {
                 cmd: CmdArg::OperationRequest(operation_request),
                 sender,
-            })
-            .await
-            .map_err(|_| RedisError::from(io::Error::from(io::ErrorKind::BrokenPipe)))?;
+            }).await?;
 
         receiver
             .await
@@ -3077,29 +3103,30 @@ where
 
         match recover_future {
             RecoverFuture::RefreshingSlots(handle) => {
-                // Check if the task has completed
-                match handle.now_or_never() {
-                    Some(Ok(Ok(()))) => {
-                        // Task succeeded
+                // Use proper poll() instead of now_or_never() to register the waker.
+                // now_or_never() consumes the future without registering a waker, so
+                // when the task is still running it returns None and we'd fall through
+                // to Ready(Ok(())) — telling poll_flush recovery is done when it isn't.
+                // This caused a busy-spin loop in poll_flush.
+                match Pin::new(handle).poll(cx) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(Ok(()))) => {
                         trace!("Slot refresh completed successfully!");
                         self.state = ConnectionState::PollComplete;
-                        return Poll::Ready(Ok(()));
+                        Poll::Ready(Ok(()))
                     }
-                    Some(Ok(Err(e))) => {
-                        // Task completed but returned an engine error
+                    Poll::Ready(Ok(Err(e))) => {
                         trace!("Slot refresh failed: {:?}", e);
 
                         if e.kind() == ErrorKind::AllConnectionsUnavailable {
-                            // If all connections unavailable, try reconnect
                             self.state =
                                 ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(
                                     Box::pin(ClusterConnInner::reconnect_to_initial_nodes(
                                         self.inner.clone(),
                                     )),
                                 ));
-                            return Poll::Ready(Err(e));
+                            Poll::Ready(Err(e))
                         } else {
-                            // Retry refresh
                             let new_handle = Self::spawn_refresh_slots_task(
                                 self.inner.clone(),
                                 &RefreshPolicy::Throttable,
@@ -3107,46 +3134,31 @@ where
                             self.state = ConnectionState::Recover(RecoverFuture::RefreshingSlots(
                                 new_handle,
                             ));
-                            return Poll::Ready(Ok(()));
+                            Poll::Ready(Ok(()))
                         }
                     }
-                    Some(Err(join_err)) => {
+                    Poll::Ready(Err(join_err)) => {
                         if join_err.is_cancelled() {
-                            // Task was intentionally aborted - don't treat as an error
                             trace!("Slot refresh task was aborted");
                             self.state = ConnectionState::PollComplete;
-                            return Poll::Ready(Ok(()));
+                            Poll::Ready(Ok(()))
                         } else {
-                            // Task panicked - try reconnecting to initial nodes as a recovery strategy
                             warn!("Slot refresh task panicked: {:?} - attempting recovery by reconnecting to initial nodes", join_err);
-
-                            // TODO - consider a gracefully closing of the client
-                            // Since a panic indicates a bug in the refresh logic,
-                            // it might be safer to close the client entirely
                             self.state =
                                 ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(
                                     Box::pin(ClusterConnInner::reconnect_to_initial_nodes(
                                         self.inner.clone(),
                                     )),
                                 ));
-
-                            // Report this critical error to clients
                             let err = RedisError::from((
                                 ErrorKind::ClientError,
                                 "Slot refresh task panicked",
                                 format!("{join_err:?}"),
                             ));
-                            return Poll::Ready(Err(err));
+                            Poll::Ready(Err(err))
                         }
                     }
-                    None => {
-                        // Task is still running
-                        // Just continue and return Ok to not block poll_flush
-                    }
                 }
-
-                // Always return Ready to not block poll_flush
-                Poll::Ready(Ok(()))
             }
             // Other cases remain unchanged
             RecoverFuture::ReconnectToInitialNodes(ref mut future) => {
@@ -3201,6 +3213,22 @@ where
         }
     }
 
+    /// Fail all pending requests immediately with ClientError.
+    /// Called when entering recovery to prevent requests from waiting
+    /// for slow reconnection cycles. The error maps to NoRetry so
+    /// callers get fast errors without triggering more reconnections.
+    fn fail_pending_requests(inner: &Core<C>) {
+        let mut guard = inner.pending_requests.lock().unwrap();
+        let requests = std::mem::take(&mut *guard);
+        drop(guard);
+        for request in requests {
+            let _ = request.sender.send(Err(RedisError::from((
+                ErrorKind::ClientError,
+                "Connection in recovery",
+            ))));
+        }
+    }
+
     fn poll_complete(&mut self, cx: &mut task::Context<'_>) -> Poll<PollFlushAction> {
         let retry_params = self
             .inner
@@ -3208,6 +3236,11 @@ where
             .expect(MUTEX_READ_ERR);
         let mut poll_flush_action = PollFlushAction::None;
         let mut pending_requests_guard = self.inner.pending_requests.lock().unwrap();
+        let pending_count = pending_requests_guard.len();
+        let inflight_count = self.in_flight_requests.len();
+        if pending_count > 0 || inflight_count > 0 {
+            trace!("poll_complete: pending={} inflight={}", pending_count, inflight_count);
+        }
         if !pending_requests_guard.is_empty() {
             let mut pending_requests = mem::take(&mut *pending_requests_guard);
             for request in pending_requests.drain(..) {
@@ -3409,52 +3442,81 @@ where
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::Error>> {
         trace!("poll_flush: {:?}", self.state);
-        loop {
-            self.send_refresh_error();
+        POLL_FLUSH_CALLS.fetch_add(1, AtomicOrdering::Relaxed);
+        log_diag_counters();
+        // No loop{} here — when recovery is needed, we enter recovery state and
+        // return Pending. The batch-drain loop will re-call flush() which re-polls
+        // us. This prevents busy-spinning the single-threaded Tokio runtime during
+        // sustained partition, allowing timers and other tasks to make progress.
+        self.send_refresh_error();
 
-            if let Err(err) = ready!(self.as_mut().poll_recover(cx)) {
-                // We failed to reconnect, while we will try again we will report the
-                // error if we can to avoid getting trapped in an infinite loop of
-                // trying to reconnect
+        match self.as_mut().poll_recover(cx) {
+            Poll::Pending => {
+                POLL_RECOVER_PENDING.fetch_add(1, AtomicOrdering::Relaxed);
+                // Fail any requests that Forward put into pending_requests
+                // via start_send while we're in recovery. Without this,
+                // those requests wait for recovery to complete (~seconds),
+                // blocking Java threads on run_with_timeout (1000ms).
+                ClusterConnInner::fail_pending_requests(&self.inner);
+                return Poll::Pending;
+            }
+            Poll::Ready(Err(err)) => {
+                POLL_RECOVER_READY.fetch_add(1, AtomicOrdering::Relaxed);
                 self.refresh_error = Some(err);
-
-                // Give other tasks a chance to progress before we try to recover
-                // again. Since the future may not have registered a wake up we do so
-                // now so the task is not forgotten
                 cx.waker().wake_by_ref();
                 return Poll::Pending;
             }
+            Poll::Ready(Ok(())) => {
+                POLL_RECOVER_READY.fetch_add(1, AtomicOrdering::Relaxed);
+            }
+        }
 
-            match ready!(self.poll_complete(cx)) {
-                PollFlushAction::None => return Poll::Ready(Ok(())),
-                PollFlushAction::RebuildSlots => {
-                    // Spawn refresh task
-                    let task_handle = ClusterConnInner::spawn_refresh_slots_task(
-                        self.inner.clone(),
-                        &RefreshPolicy::Throttable,
-                    );
-
-                    // Update state
-                    self.state =
-                        ConnectionState::Recover(RecoverFuture::RefreshingSlots(task_handle));
-                }
-                PollFlushAction::ReconnectFromInitialConnections => {
-                    self.state =
-                        ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(Box::pin(
-                            ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
-                        )));
-                }
-                PollFlushAction::Reconnect(addresses) => {
-                    self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
-                        ClusterConnInner::trigger_refresh_connection_tasks(
-                            self.inner.clone(),
-                            addresses,
-                            RefreshConnectionType::OnlyUserConnection,
-                            true,
-                        )
-                        .map(|_| ()), // Convert Vec<Arc<Notify>> to () as it's not needed here
+        let poll_complete_result = self.as_mut().poll_complete(cx);
+        match poll_complete_result {
+            Poll::Pending => {
+                POLL_COMPLETE_PENDING.fetch_add(1, AtomicOrdering::Relaxed);
+                return Poll::Pending;
+            }
+            Poll::Ready(PollFlushAction::None) => {
+                POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(PollFlushAction::RebuildSlots) => {
+                POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
+                ClusterConnInner::fail_pending_requests(&self.inner);
+                let task_handle = ClusterConnInner::spawn_refresh_slots_task(
+                    self.inner.clone(),
+                    &RefreshPolicy::Throttable,
+                );
+                self.state =
+                    ConnectionState::Recover(RecoverFuture::RefreshingSlots(task_handle));
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(PollFlushAction::ReconnectFromInitialConnections) => {
+                POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
+                ClusterConnInner::fail_pending_requests(&self.inner);
+                self.state =
+                    ConnectionState::Recover(RecoverFuture::ReconnectToInitialNodes(Box::pin(
+                        ClusterConnInner::reconnect_to_initial_nodes(self.inner.clone()),
                     )));
-                }
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            Poll::Ready(PollFlushAction::Reconnect(addresses)) => {
+                POLL_COMPLETE_READY.fetch_add(1, AtomicOrdering::Relaxed);
+                ClusterConnInner::fail_pending_requests(&self.inner);
+                self.state = ConnectionState::Recover(RecoverFuture::Reconnect(Box::pin(
+                    ClusterConnInner::trigger_refresh_connection_tasks(
+                        self.inner.clone(),
+                        addresses,
+                        RefreshConnectionType::OnlyUserConnection,
+                        true,
+                    )
+                    .map(|_| ()),
+                )));
+                cx.waker().wake_by_ref();
+                Poll::Pending
             }
         }
     }

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -1143,6 +1143,11 @@ impl RedisError {
 
                     io::ErrorKind::PermissionDenied => RetryMethod::NoRetry,
                     io::ErrorKind::Unsupported => RetryMethod::NoRetry,
+                    // Response timeouts are returned to the caller without triggering
+                    // reconnection. During network partition, dead connections are
+                    // recovered via FatalSendError (pipeline send timeout) which maps
+                    // to ReconnectAndRetry. Using Reconnect here would cause
+                    // reconnection storms from normal latency jitter.
                     io::ErrorKind::TimedOut => RetryMethod::NoRetry,
 
                     _ => RetryMethod::RetryImmediately,

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -250,10 +250,6 @@ async fn run_with_timeout<T>(
         Some(duration) => match tokio::time::timeout(duration, future).await {
             Ok(result) => result,
             Err(_) => {
-                log_warn(
-                    "run_with_timeout",
-                    format!("request timed out after {}ms", duration.as_millis()),
-                );
                 // Record timeout error metric if telemetry is initialized
                 if let Err(e) = GlideOpenTelemetry::record_timeout_error() {
                     log_error(
@@ -1219,8 +1215,7 @@ async fn create_cluster_client(
         // This ensures requests already in the pipeline fail within 500ms
         // (for 1000ms request_timeout) instead of waiting for TCP retransmit
         // timeout (~6.5 minutes). The /2 factor leaves room for one retry
-        // within the overall request_timeout budget while being generous
-        // enough for initial cluster topology discovery and TLS handshakes.
+        // within the overall request_timeout budget.
         .response_timeout(to_duration(request.request_timeout, DEFAULT_RESPONSE_TIMEOUT) / 2)
         .retries(DEFAULT_RETRIES);
     let read_from_strategy = request.read_from.unwrap_or_default();

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -250,6 +250,10 @@ async fn run_with_timeout<T>(
         Some(duration) => match tokio::time::timeout(duration, future).await {
             Ok(result) => result,
             Err(_) => {
+                log_warn(
+                    "run_with_timeout",
+                    format!("request timed out after {}ms", duration.as_millis()),
+                );
                 // Record timeout error metric if telemetry is initialized
                 if let Err(e) = GlideOpenTelemetry::record_timeout_error() {
                     log_error(
@@ -1210,6 +1214,14 @@ async fn create_cluster_client(
     let connection_timeout = to_duration(request.connection_timeout, DEFAULT_CONNECTION_TIMEOUT);
     let mut builder = redis::cluster::ClusterClientBuilder::new(initial_nodes)
         .connection_timeout(connection_timeout)
+        // Set response_timeout to request_timeout/2 as defense-in-depth.
+        // Previously Duration::MAX — no connection-level timeout at all.
+        // This ensures requests already in the pipeline fail within 500ms
+        // (for 1000ms request_timeout) instead of waiting for TCP retransmit
+        // timeout (~6.5 minutes). The /2 factor leaves room for one retry
+        // within the overall request_timeout budget while being generous
+        // enough for initial cluster topology discovery and TLS handshakes.
+        .response_timeout(to_duration(request.request_timeout, DEFAULT_RESPONSE_TIMEOUT) / 2)
         .retries(DEFAULT_RETRIES);
     let read_from_strategy = request.read_from.unwrap_or_default();
     builder = builder.read_from(match read_from_strategy {

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -532,19 +532,13 @@ fn get_route(
 }
 
 fn handle_request(request: CommandRequest, mut client: Client, writer: Rc<Writer>) {
-    let callback_idx = request.callback_idx;
     task::spawn_local(async move {
-        let start = std::time::Instant::now();
         let mut updated_inflight_counter = true;
         let client_clone = client.clone();
 
         let result = match client.reserve_inflight_request() {
             false => {
                 updated_inflight_counter = false;
-                log_warn(
-                    "handle_request",
-                    format!("cb={} REJECTED: max inflight reached", callback_idx),
-                );
                 Err(ClientUsageError::User(
                     "Reached maximum inflight requests".to_string(),
                 ))
@@ -641,19 +635,6 @@ fn handle_request(request: CommandRequest, mut client: Client, writer: Rc<Writer
 
         if updated_inflight_counter {
             client_clone.release_inflight_request();
-        }
-
-        let elapsed_ms = start.elapsed().as_millis();
-        if elapsed_ms > 500 || result.is_err() {
-            log_warn(
-                "handle_request",
-                format!(
-                    "cb={} elapsed={}ms ok={}",
-                    callback_idx,
-                    elapsed_ms,
-                    result.is_ok()
-                ),
-            );
         }
 
         let _res = write_result(result, request.callback_idx, &writer, request.root_span_ptr).await;

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -532,13 +532,19 @@ fn get_route(
 }
 
 fn handle_request(request: CommandRequest, mut client: Client, writer: Rc<Writer>) {
+    let callback_idx = request.callback_idx;
     task::spawn_local(async move {
+        let start = std::time::Instant::now();
         let mut updated_inflight_counter = true;
         let client_clone = client.clone();
 
         let result = match client.reserve_inflight_request() {
             false => {
                 updated_inflight_counter = false;
+                log_warn(
+                    "handle_request",
+                    format!("cb={} REJECTED: max inflight reached", callback_idx),
+                );
                 Err(ClientUsageError::User(
                     "Reached maximum inflight requests".to_string(),
                 ))
@@ -635,6 +641,19 @@ fn handle_request(request: CommandRequest, mut client: Client, writer: Rc<Writer
 
         if updated_inflight_counter {
             client_clone.release_inflight_request();
+        }
+
+        let elapsed_ms = start.elapsed().as_millis();
+        if elapsed_ms > 500 || result.is_err() {
+            log_warn(
+                "handle_request",
+                format!(
+                    "cb={} elapsed={}ms ok={}",
+                    callback_idx,
+                    elapsed_ms,
+                    result.is_ok()
+                ),
+            );
         }
 
         let _res = write_result(result, request.callback_idx, &writer, request.root_span_ptr).await;


### PR DESCRIPTION
# Root Cause Analysis: Valkey GLIDE Java Thread-Hang / OOM

**Version:** v2.2.7
**Reproduction (Different triggers / Same Issue):**

1. **Network partition (iptables):** `iptables -A OUTPUT -p tcp -d <ip> --dport 6379 -j DROP` — simulates VPC peering failure / half-open TCP. Outgoing packets silently dropped, TCP connections appear alive but no responses arrive. Pipeline buffer (50) fills, `response_timeout=Duration::MAX` prevents recovery, `.get()` calls are blocked.

**With the current fix: GLIDE eventually detects the connection is dead (TCP retransmit timeouts) and returns errors**

2. **No network manipulation (CLIENT PAUSE):** Connect to one primary node via `valkey-cli` and run:
   
  `valkey-cli --tls -h <shard-primary-endpoint> -p 6379 CLIENT PAUSE 300000`
  

   Pauses client command processing on a single primary for 5 minutes. TCP connections stay alive but the server stops responding. Sufficient to trigger the deadlock because the single Tokio worker thread blocks on the paused shard's full pipeline buffer (50) and can no longer process responses from healthy shards — cascading to all connections.

**With the current fix:  With CLIENT PAUSE, the TCP connection stays alive and GLIDE waits during TIMEOUT**


3. **IAM token refresh + full network outage (Security Group revocation):** When IAM authentication is enabled, GLIDE periodically refreshes the session token and reconnects to all nodes. If a network outage occurs during or shortly after this reconnection (e.g., Security Group revocation dropping all traffic), every connection is in a fresh/reconnecting state simultaneously. No healthy connections remain to fall back to — all pipeline buffers fill, all 
try_request futures block on pipeline.send().await
, and the cluster task never enters recovery. This is the compound trigger seen in production: IAM refresh widens the blast radius from one shard to all shards, turning a partial outage into a total deadlock. See [PR #2](https://github.com/alexey-temnikov/valkey-glide/pull/2) for the IAM-specific reconnection bug.

**Note:** Issue is also reproducible on v.2.1.1 (see below - Before Fix (v2.1.1))

---

## Summary

Under sustained network partition (half-open TCP, or server issues causing connection to hang), Java worker threads using `CompletableFuture.get()` experience queue growth to OOM. The root cause is that requests take ~1000ms to fail (via `run_with_timeout`) while the submission rate can be higher (e.g. ~6000/sec). With 60 threads, only ~60 errors/sec are delivered — the queue grows at ~5940/sec.

Five fixes reduce error latency from **1000ms to <1ms**, matching the production rate and keeping queue=0.

Note: Current fix also helps to mitigate bug in https://github.com/alexey-temnikov/valkey-glide/pull/2 that causes same symptoms (with different trigger / root-cause). When IAM is enabled, once session token is refreshed it causes to reconnect to all nodes, that can trigger issue when there is a connectivity outage between client and server (not hanging TCP requests - different trigger - SG revocation). Current fix mitigates the impact of that issue.  

Note: v.2.1.1 has the same issue reproducible, however in that version SYNC APIs `get()` acts the same way as `orTimeout(...).get()` in v2.2.7, see chart below.

---

## Architecture (Request Flow)

```
Java Thread                    Rust Core                           Network
───────────                    ─────────                           ───────
client.del(keys)
  │
  ├─► handle_request           [task::spawn_local on LocalSet]
  │     ├─ reserve_inflight    [atomic counter]
  │     └─ run_with_timeout(request_timeout)
  │          └─ send_command
  │               ├─ cluster_channel.send().await   ──► Cluster Task
  │               │   [bounded 100]                      │
  │               └─ oneshot.await                       ├─ Forward combinator
  │                   [waits for result]                  │   ├─ poll_fn(rx.recv) → start_send
  │                                                      │   │   [puts msg in pending_requests]
  │                                                      │   └─ poll_flush
  │                                                      │        ├─ poll_recover
  │                                                      │        └─ poll_complete
  │                                                      │             └─ try_request
  │                                                      │                  └─ get_connection
  │                                                      │                  └─ req_packed_command
  │                                                      │                       └─ send_recv
  │                                                      │                            ├─ pipeline.send().await
  │                                                      │                            │   [bounded 50]
  │                                                      │                            └─ oneshot.await
  │                                                      │                                [response_timeout]
  │                                                      │
  │                                                      └─► Pipeline Driver Task
  │                                                           [tokio::spawn]
  │                                                           └─ PipelineSink
  │                                                                └─ TCP write ──► Server
  │
  └─► .get() / .orTimeout().get() / .thenAccept()
```

**Key:** All `handle_request` tasks and the cluster task run on the **same single-threaded** `current_thread` Tokio runtime (one per GLIDE client via `LocalPoolHandle`). The pipeline driver task runs on the same runtime via `tokio::spawn`.

---

## What Happens During Half-Open TCP (iptables DROP)

### Phase 1: Pipeline Fills (~1-2 seconds after partition)

1. `iptables -A OUTPUT ... -j DROP` silently drops outgoing TCP packets at netfilter
3. TCP kernel send buffer accepts data initially (application sees successful writes)
4. Pipeline driver reads from pipeline channel (bounded 50), writes to TCP — channel drains normally
5. TCP send buffer fills (~128KB, holds ~2500 commands at ~50 bytes each)
6. `PipelineSink::poll_flush` returns `Pending` — driver task suspends on TCP write
7. Pipeline channel (bounded 50) fills — driver can no longer drain it
8. `send_recv`'s `pipeline.send().await` returns `Pending` for new requests

**Code:** `multiplexed_connection.rs:343-344`:
```rust
const BUFFER_SIZE: usize = 50;
let (sender, mut receiver) = mpsc::channel(BUFFER_SIZE);
```

### Phase 2: Requests Accumulate as Pending Futures

In v2.2.7, the cluster task does **not** enter recovery quickly. It stays in `PollComplete` state:

1. Requests already in the pipeline (sent to TCP buffer) wait for responses
2. `response_timeout = Duration::MAX` → responses never time out (`cluster_client.rs:181`)
3. New requests' `try_request` futures call `pipeline.send().await` → `Pending` (channel full)
4. `poll_complete` polls `in_flight_requests` → all `Pending` → returns `Pending`
5. `poll_flush` returns `Pending` → Forward combinator suspends
6. Cluster task stays in `PollComplete` state — **no recovery triggered**

**Why no recovery:** Recovery requires a `try_request` future to complete with an error (e.g., `FatalSendError`, `ConnectionNotFoundForRoute`). In v2.2.7, futures are stuck on `pipeline.send().await` (no timeout) or response oneshot (timeout = `Duration::MAX`). No errors → no recovery.

**TCP connections appear healthy:** `is_closed()` checks `is_stream_closed` (`multiplexed_connection.rs:424`), which is only set when the TCP stream produces `None` (line 149). During half-open TCP, the kernel hasn't detected the failure — `is_closed()` returns `false`. Periodic `validate_all_user_connections` doesn't remove connections.

### Phase 3: Steady-State Error Delivery via run_with_timeout

New requests continue to arrive from Java threads:

1. Java thread submits → `handle_request` → `run_with_timeout(1000ms, send_command(...))`
2. `send_command` sends `Message` to cluster channel (capacity 100 > 60 threads — succeeds)
3. Forward reads Message → `start_send` → `pending_requests`
4. `poll_complete` creates `try_request` future → `pipeline.send().await` → `Pending`
5. After 1000ms, `run_with_timeout` fires → cancels `send_command` → drops oneshot receiver
6. Next time `poll_complete` polls `in_flight_requests`, the `Request` future checks `sender.is_closed()` → `true` → returns `Next::Done` → future cleaned up (`cluster_async/mod.rs:916`)
7. Java thread gets `TimeoutException`, re-submits

**Error rate:** 60 threads × 1 req/sec (1000ms per error) = **60 errors/sec**
**Production rate:** ~6000 req/sec
**Queue growth:** ~5940/sec → **OOM**

**Note:** The Tokio runtime is NOT permanently starved. All tasks are suspended on async awaits (not blocking calls). The runtime parks, timer fires after 1000ms, task is polled, timeout triggers. `run_with_timeout` fires reliably.

---

## v2.2.7 Behavior Per Worker Type

### SYNC (.get()) — Queue Grows → OOM
- Java thread blocks on `.get()` until `CompletableFuture` completes
- Error delivery: 1000ms per request (via `run_with_timeout`)
- **60 errors/sec vs 6000/sec production → queue grows at 5940/sec → OOM**

### ASYNC (thenAccept) — Inflight Exhaustion
- Non-blocking: Java thread submits and continues immediately
- Each `handle_request` task holds one inflight slot for ~1000ms (until `run_with_timeout`)
- ASYNC submits at ~6000/sec → steady-state concurrent tasks: 6000 × 1.0s = 6000
- `maxInflightRequests` = 1000 → inflight reaches 1000 in ~167ms
- After that: new requests rejected with "Reached maximum inflight requests" (no Rust work)
- **Result: inflight=1000 permanently, queue=0 (errors flow fast via rejection)**

### SYNC+T (.orTimeout().get()) — Works Until Inflight Exhaustion
- `.orTimeout(1050ms)` completes the Java future independently of Rust
- `run_with_timeout(1000ms)` fires first → Rust task completes → inflight released
- Errors flow at ~60/sec (same as SYNC), but Java timeout prevents thread hang
- **queue=0 as long as inflight slots are available**
- Over extended partitions: if `run_with_timeout` is delayed (runtime busy), inflight can leak gradually

---

## With All 5 Fixes — Behavior During Partition

### What the Fixes Do

| Fix | File | What | Effect |
|-----|------|------|--------|
| **1** | `multiplexed_connection.rs` | `tokio::time::timeout(100ms, pipeline.send())` | `try_request` completes with `FatalSendError` in 100ms instead of blocking forever. **Triggers recovery.** |
| **2** | `cluster_async/mod.rs` | Remove `loop{}` from `poll_flush`, single-pass with `Pending` on recovery | Prevents busy-spin when Fix 1 causes fast-completing errors. |
| **3** | `cluster_async/mod.rs` | `now_or_never()` → `Pin::new(handle).poll(cx)` for RefreshingSlots | Proper waker registration. `now_or_never()` returns `Ready` without registering waker, feeding the busy-spin. |
| **4** | `client/mod.rs` | `response_timeout = request_timeout / 2` (500ms) | Defense-in-depth for requests already in pipeline. Previously `Duration::MAX`. |
| **5** | `cluster_async/mod.rs` | `fail_pending_requests` on recovery entry AND when `poll_recover` returns `Pending` | Requests that Forward puts into `pending_requests` during recovery are failed in **<1ms**. |

### How Fix 1 Changes the Dynamics

Without Fix 1 (v2.2.7): `pipeline.send().await` blocks forever → `try_request` futures are `Pending` → `poll_complete` returns `Pending` → cluster task stays in `PollComplete` → **no recovery triggered**.

With Fix 1: `pipeline.send()` times out after 100ms → `FatalSendError` → `try_request` completes with error → `poll_complete` returns `Ready(Reconnect)` → **cluster task enters recovery within ~100ms**.

### Why Fixes 2+3 Are Needed (Only Because of Fix 1)

In v2.2.7, `poll_flush`'s `loop{}` doesn't busy-spin because `try_request` futures are `Pending` (stuck on `pipeline.send().await`). `poll_complete` returns `Pending`, the `ready!` macro exits the loop.

Fix 1 changes this: `try_request` completes fast with `FatalSendError`. `poll_complete` returns `Ready(Reconnect)`. State changes to `Recover(RefreshingSlots)`. The loop continues → `poll_recover` → `now_or_never()` → `None` → returns `Ready(Ok(()))` (line 3148: "Always return Ready to not block poll_flush") → loop continues → `poll_complete` → more fast errors → `Ready(RebuildSlots)` → loop continues → **busy-spin at ~30,000 calls/5s**, starving the runtime.

Fix 2 (single-pass, return `Pending` on recovery) + Fix 3 (proper `poll(cx)` with waker) break the busy-spin.

**Instrumentation proof (with Fixes 1-5):**
```
Before block:  poll_flush=30000/5s  (busy-spin without Fix 2+3)
During block:  poll_flush=322/5s    recover(ready=1, pending=321)  ← properly yielding
```

### Why Fix 5 Is Critical

Without Fix 5, requests follow this path during recovery:
1. Forward reads from cluster channel → `start_send` → `pending_requests`
2. Forward calls `poll_flush` → `poll_recover` → `Pending` (in recovery)
3. Request sits in `pending_requests` until recovery completes (seconds)
4. `handle_request` task waits on oneshot → `run_with_timeout` fires at 1000ms
5. **Error takes 1000ms** → 60 errors/sec → queue grows

With Fix 5:
1. Forward reads from cluster channel → `start_send` → `pending_requests`
2. Forward calls `poll_flush` → `poll_recover` → `Pending` → **`fail_pending_requests()`**
3. Request's oneshot completed immediately with `ClientError("Connection in recovery")`
4. `handle_request` task gets error in <1ms
5. **Error takes <1ms** → ~6000 errors/sec → queue stays at 0

Fix 5 is called both when **entering** recovery (the 3 `PollFlushAction` branches) AND when `poll_recover` returns `Pending`. The second call site is critical: it fails requests that Forward puts into `pending_requests` via `start_send` while the cluster task is already in recovery.

### Cluster Channel Backpressure Preserved

Fix 5 uses `send().await` on the cluster channel (not `try_send`). This preserves backpressure: when the channel is full, Java threads block on `send().await` for up to 1000ms (`run_with_timeout`). During this quiet window, the cluster task has uninterrupted time to complete recovery. When recovery succeeds, the next batch of requests succeeds → queue drains.

An earlier attempt used `try_send` (instant failure when channel full). This broke SYNC recovery: threads re-submitted immediately, the cluster channel stayed full, the cluster task never got a quiet recovery window.

---

## Results (15-minute iptables DROP)

**Steady state:** All workers +5952/s, errors=0 from startup.

| Worker | v2.2.7 (no fix) | With all fixes |
|--------|-----------------|----------------|
| **SYNC (.get())** | queue grows → OOM | **queue=0**, stuck=20 transient |
| **SYNCTIMEOUT (.orTimeout)** | queue=0 short-term, degrades long-term | **queue=0** for 15min+ |
| **ASYNC (thenAccept)** | inflight=1000, queue=0 | **inflight=0**, queue=0 |
| **Error latency** | ~1000ms (run_with_timeout) | <1ms (fail_pending_requests) |
| **Error throughput** | ~60/sec | ~6000/sec |
| **Recovery after restore** | All resume | All resume +5952/s |

### Before Fix (v2.2.7)
<img width="2400" height="1200" alt="queue_vs_time" src="https://github.com/user-attachments/assets/dd713c05-3a9d-4ee7-8352-48552e95effc" />

### Before Fix (v2.1.1)
<img width="2400" height="1200" alt="queue_vs_time" src="https://github.com/user-attachments/assets/d97bebf3-b9c4-457b-b830-98245f23b1c3" />


### After Fix (v2.2.x)
<img width="2400" height="1200" alt="queue_vs_time" src="https://github.com/user-attachments/assets/c9c1fa74-b2f2-4b5e-b9b2-c61f7e7d2d7d" />

### After Fix - Scenario + IAM On + Revoke SG (https://github.com/alexey-temnikov/valkey-glide/pull/2)
<img width="2400" height="1200" alt="queue_vs_time" src="https://github.com/user-attachments/assets/f6fcaa1d-a83d-466a-9daa-32d99a46bdeb" />


---

## Files Changed

```
multiplexed_connection.rs  | Fix 1: pipeline send 100ms timeout + diagnostic counter
cluster_async/mod.rs       | Fix 2: poll_flush single-pass
                           | Fix 3: now_or_never → proper poll
                           | Fix 5: fail_pending_requests + diagnostic counters
client/mod.rs              | Fix 4: response_timeout = request_timeout/2
socket_listener.rs         | Instrumentation (handle_request timing)
types.rs                   | Comment: TimedOut → NoRetry rationale

5 files changed, 232 insertions(+), 113 deletions(-)
```
